### PR TITLE
Update containerd-wasm-shims to 0.7.0

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add gcc automake autoconf libtool gettext pkgconf make musl-dev python3 
     && curl https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p /usr/local --version=0.12.1 \
     && cd / && git clone --depth 1 --branch 1.8.1 https://github.com/containers/crun.git \
     && cd crun \
-    && ./autogen.sh \    
+    && ./autogen.sh \
     && ./configure --with-wasmedge --enable-embedded-yajl --disable-systemd \
     && make \
     && mv crun crun-wasmedge-musl
@@ -33,7 +33,7 @@ FROM ubuntu:18.04 as builder-containerd-shim
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
-RUN curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.6.0/containerd-wasm-shims-v1-linux-$(uname -m).tar.gz | tar -xzf - \
+RUN curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.7.0/containerd-wasm-shims-v1-linux-$(uname -m).tar.gz | tar -xzf - \
     && curl -L https://github.com/second-state/runwasi/releases/download/v0.3.2/containerd-shim-wasmedge-v1-v0.3.2-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf -
 
 FROM ubuntu:18.04 as builder-containerd-shim-spin
@@ -73,6 +73,6 @@ COPY --link --from=builder-crun-alpine /WasmEdge/buildmusl/lib/api/libwasmedge.s
 COPY --link --from=builder-containerd-shim /containerd-shim-slight-v1 /assets/containerd-shim-slight-v1
 COPY --link --from=builder-containerd-shim /containerd-shim-spin-v1 /assets/containerd-shim-spin-v1
 COPY --link --from=builder-containerd-shim /containerd-shim-wasmedge-v1 /assets/containerd-shim-wasmedge-v1
-#COPY --link --from=builder-containerd-shim-spin /containerd-wasm-shims/containerd-shim-spin-v1/target/release/containerd-shim-spin-v1 /assets/containerd-shim-spin-v1
+COPY --link --from=builder-containerd-shim /containerd-shim-wws-v1 /assets/containerd-shim-wws-v1
 
 CMD sh /script/installer.sh wasmedge

--- a/script/installer.sh
+++ b/script/installer.sh
@@ -51,20 +51,23 @@ esac
 
 cp /assets/containerd-shim-spin-v1 $NODE_ROOT$KWASM_DIR/bin/containerd-shim-spin-v1
 cp /assets/containerd-shim-wasmedge-v1 $NODE_ROOT$KWASM_DIR/bin/containerd-shim-wasmedge-v1
+cp /assets/containerd-shim-wws-v1 $NODE_ROOT$KWASM_DIR/bin/containerd-shim-wws-v1
 if [ -f $NODE_ROOT/usr/local/bin/containerd-shim-spin-v1 ]; then
     # Replace existing spin shim on Azure AKS nodes
     ln -sf $KWASM_DIR/bin/containerd-shim-spin-v1 $NODE_ROOT/usr/local/bin/containerd-shim-spin-v1
     ln -sf $KWASM_DIR/bin/containerd-shim-wasmedge-v1 $NODE_ROOT/usr/local/bin/containerd-shim-wasmedge-v1
+    ln -sf $KWASM_DIR/bin/containerd-shim-wws-v1 $NODE_ROOT/usr/local/bin/containerd-shim-wws-v1
 elif ! $IS_MICROK8S; then
     ln -sf $KWASM_DIR/bin/containerd-shim-spin-v1 $NODE_ROOT/bin/
     ln -sf $KWASM_DIR/bin/containerd-shim-wasmedge-v1 $NODE_ROOT/bin/
+    ln -sf $KWASM_DIR/bin/containerd-shim-wws-v1 $NODE_ROOT/bin/
 fi
 
 CRI='"io.containerd.grpc.v1.cri"'
 if $IS_K3S; then
     CRI='cri'
 fi
-if ! grep -q crun $NODE_ROOT$CONTAINERD_CONF; then  
+if ! grep -q crun $NODE_ROOT$CONTAINERD_CONF; then
     echo '[plugins.'$CRI'.containerd.runtimes.crun]
     runtime_type = "io.containerd.runc.v2"
     pod_annotations = ["module.wasm.image/variant", "run.oci.handler"]
@@ -73,7 +76,9 @@ if ! grep -q crun $NODE_ROOT$CONTAINERD_CONF; then
 [plugins.'$CRI'.containerd.runtimes.spin]
     runtime_type = "io.containerd.spin.v1"
 [plugins.'$CRI'.containerd.runtimes.wasmedge]
-    runtime_type = "io.containerd.wasmedge.v1"' >> $NODE_ROOT$CONTAINERD_CONF
+    runtime_type = "io.containerd.wasmedge.v1"
+[plugins.'$CRI'.containerd.runtimes.wws]
+    runtime_type = "io.containerd.wws.v1"' >> $NODE_ROOT$CONTAINERD_CONF
     rm -Rf $NODE_ROOT$KWASM_DIR/opt/kwasm/active
 fi
 


### PR DESCRIPTION
Bump containerd-wasm-shims to 0.7.0 that contains the Wasm Workers Server (WWS) shim.

Fixes: https://github.com/KWasm/kwasm-node-installer/issues/28