### PR TITLE
Prepare for 0.3.0

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,10 +23,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - 
         name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
       - 
         name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - 
@@ -45,13 +45,21 @@ jobs:
         # Setup docker build to use your Namespace workspace builder
         name: Set up Namespace Buildx
         uses: namespacelabs/nscloud-setup-buildx-action@v0
+      - name: Build runwasi as static muls for amd64 and arm64
+        run: |
+          git clone https://github.com/containerd/runwasi.git &&
+          cd runwasi &&
+          docker build --platform=linux/arm64,linux/amd64 --build-arg BASE_IMAGE=alpine --build-arg CRATE="containerd-shim-wasmtime,containerd-shim-wasmedge,containerd-shim-wasmer" -t nscr.io/a8fcp47vcfori/build-runwasi --push . &&
+          cd -
       - 
         name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            CONTAINERD_RUNWASI=nscr.io/a8fcp47vcfori/build-runwasi
           tags: ${{ steps.meta.outputs.tags }}
           file: images/installer/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -47,8 +47,9 @@ jobs:
         uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Build runwasi as static muls for amd64 and arm64
         run: |
-          git clone https://github.com/containerd/runwasi.git &&
+          git clone --branch containerd-shim-wasm/v0.3.0 --depth 1 https://github.com/containerd/runwasi.git &&
           cd runwasi &&
+          rm Cargo.lock &&
           docker build --platform=linux/arm64,linux/amd64 --build-arg BASE_IMAGE=alpine --build-arg CRATE="containerd-shim-wasmtime,containerd-shim-wasmedge,containerd-shim-wasmer" -t nscr.io/a8fcp47vcfori/build-runwasi --push . &&
           cd -
       - 

--- a/example/install-job.yaml
+++ b/example/install-job.yaml
@@ -21,7 +21,7 @@ spec:
             name: entrypoint
             defaultMode: 0744
       containers:
-        - image: docker.io/0xe282b0/kwasm-installer:0.1.0
+        - image: ghcr.io/kwasm/kwasm-node-installer:pr-42
           name: kwasm-initializer
           env:
             - name: NODE_ROOT

--- a/example/install-job.yaml
+++ b/example/install-job.yaml
@@ -21,7 +21,7 @@ spec:
             name: entrypoint
             defaultMode: 0744
       containers:
-        - image: ghcr.io/kwasm/kwasm-node-installer:pr-42
+        - image: ghcr.io/kwasm/kwasm-node-installer:master
           name: kwasm-initializer
           env:
             - name: NODE_ROOT

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -4,9 +4,9 @@ FROM ubuntu:22.04 AS download-containerd-runwasi
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
-RUN mkdir /assets \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.1.1/containerd-shim-wasmedge-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.1.1/containerd-shim-wasmtime-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/
+RUN mkdir -p /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.2.0/containerd-shim-wasmedge-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.2.0/containerd-shim-wasmtime-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/
 
 FROM ${CONTAINERD_RUNWASI} AS containerd_runwasi
 
@@ -16,10 +16,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN mkdir /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
 
 
 FROM busybox

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -1,78 +1,32 @@
-FROM ubuntu:18.04 as builder-crun
+ARG CONTAINERD_RUNWASI="download-containerd-runwasi"
 
+FROM ubuntu:22.04 AS download-containerd-runwasi
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y curl make git gcc build-essential pkgconf libtool libsystemd-dev libprotobuf-c-dev libcap-dev libseccomp-dev libyajl-dev go-md2man libtool autoconf python3 automake xz-utils \
-    && curl https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p /usr/local --version=0.11.2 \
-    && git clone --depth 1 --branch 1.8.1 https://github.com/containers/crun.git \
-    && cd crun \
-    && ./autogen.sh \
-    && ./configure --with-wasmedge --enable-embedded-yajl \
-    && make \
-    && mv crun crun-wasmedge
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-$(uname -m)-linux-c-api.tar.xz | tar xJf - -C / \
-    && cp -R /wasmtime-v1.0.1-$(uname -m)-linux-c-api/* /usr/local/ \
-    && cd /crun \
-    && ./configure --with-wasmtime --enable-embedded-yajl \
-    && make \
-    && mv crun crun-wasmtime
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
-FROM alpine:3.18 as builder-crun-alpine
-RUN apk add gcc automake autoconf libtool gettext pkgconf make musl-dev python3 libcap-dev libseccomp-dev yajl-dev argp-standalone go-md2man curl bash coreutils cmake ninja clang lld-dev llvm-dev boost-dev llvm-static git \
-    && cd / && git clone --depth 1 --branch 0.12.1 https://github.com/WasmEdge/WasmEdge.git \
-    && cd WasmEdge && bash -c "export CC=clang && export CXX=clang++ && cmake -Bbuildmusl -GNinja -DCMAKE_BUILD_TYPE=Release . && cmake --build buildmusl" \
-    && curl https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p /usr/local --version=0.12.1 \
-    && cd / && git clone --depth 1 --branch 1.8.1 https://github.com/containers/crun.git \
-    && cd crun \
-    && ./autogen.sh \
-    && ./configure --with-wasmedge --enable-embedded-yajl --disable-systemd \
-    && make \
-    && mv crun crun-wasmedge-musl
+RUN mkdir /assets \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.1.1/containerd-shim-wasmedge-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.1.1/containerd-shim-wasmtime-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/
 
-FROM ubuntu:18.04 as builder-containerd-shim
+FROM ${CONTAINERD_RUNWASI} AS containerd_runwasi
+
+FROM ubuntu:22.04 AS deislabs_containerd-wasm-shims
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
-RUN curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.8.0/containerd-wasm-shims-v1-linux-$(uname -m).tar.gz | tar -xzf - \
-    && curl -L https://github.com/second-state/runwasi/releases/download/v0.3.2/containerd-shim-wasmedge-v1-v0.3.2-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf -
+RUN mkdir /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.0/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
 
-FROM ubuntu:18.04 as builder-containerd-shim-spin
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y git curl libclang-dev make build-essential clang\
-    && git clone --depth 1 --branch main https://github.com/deislabs/containerd-wasm-shims.git
-WORKDIR /containerd-wasm-shims
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup && chmod +x ./rustup \
-    && ./rustup -y \
-    && bash -c "source ~/.cargo/env && make build-spin"
-
-FROM busybox as crun-wasmtime
-
-COPY --link --from=builder-crun /crun/crun-wasmtime /assets/crun-wasmtime
-COPY --link --from=builder-crun /usr/local/lib/libwasmtime.so /assets/libwasmtime.so
-COPY script/installer.sh /script/installer.sh
-
-CMD sh /script/installer.sh wasmtime
-
-FROM busybox as crun-wasmedge
-
-COPY --link --from=builder-crun /crun/crun-wasmedge /assets/crun-wasmedge
-COPY --link --from=builder-crun-alpine /crun/crun-wasmedge-musl /assets/crun-wasmedge-musl
-COPY --link --from=builder-crun /usr/local/lib/libwasmedge.so /assets/libwasmedge.so
-COPY script/installer.sh /script/installer.sh
-
-CMD sh /script/installer.sh wasmedge
 
 FROM busybox
 
 COPY script/installer.sh /script/installer.sh
-COPY --link --from=builder-crun /crun/crun-* /assets/
-COPY --link --from=builder-crun /usr/local/lib/libwasmedge.so /assets/libwasmedge.so
-COPY --link --from=builder-crun /usr/local/lib/libwasmtime.so /assets/libwasmtime.so
-COPY --link --from=builder-crun-alpine /crun/crun-wasmedge-musl /assets/crun-wasmedge-musl
-COPY --link --from=builder-crun-alpine /WasmEdge/buildmusl/lib/api/libwasmedge.so /assets/libwasmedge-musl.so
-COPY --link --from=builder-containerd-shim /containerd-shim-slight-v1 /assets/containerd-shim-slight-v1
-COPY --link --from=builder-containerd-shim /containerd-shim-spin-v1 /assets/containerd-shim-spin-v1
-COPY --link --from=builder-containerd-shim /containerd-shim-wasmedge-v1 /assets/containerd-shim-wasmedge-v1
-COPY --link --from=builder-containerd-shim /containerd-shim-wws-v1 /assets/containerd-shim-wws-v1
-
+COPY --link --from=deislabs_containerd-wasm-shims /assets /assets
+COPY --link --from=containerd_runwasi /containerd-shim-wasmedge-v1 /assets/
+COPY --link --from=containerd_runwasi /containerd-shim-wasmer-v1 /assets/
+COPY --link --from=containerd_runwasi /containerd-shim-wasmtime-v1 /assets/
 CMD sh /script/installer.sh wasmedge

--- a/script/installer.sh
+++ b/script/installer.sh
@@ -26,24 +26,24 @@ mkdir -p $NODE_ROOT$KWASM_DIR/bin/
 cp /assets/containerd-shim-* $NODE_ROOT$KWASM_DIR/bin/
 
 # TODO check if runtime config is already present
-if ! grep -q crun $NODE_ROOT$CONTAINERD_CONF; then
+if ! grep -q wasmtime $NODE_ROOT$CONTAINERD_CONF; then
     echo '
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.lunatic]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-lunatic-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-lunatic-v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-slight-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-slight-v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-spin-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-spin-v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wws]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-wws-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-wws-v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasmedge]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-wasmedge-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-wasmedge-v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasmer]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-wasmer-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-wasmer-v1"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasmtime]
-    runtime_type = "/opt/kwasm/bin/containerd-shim-wasmtime-v1"
+    runtime_type = "'$KWASM_DIR'/bin/containerd-shim-wasmtime-v1"
 ' >> $NODE_ROOT$CONTAINERD_CONF
-    rm -Rf $NODE_ROOT$KWASM_DIR/opt/kwasm/active
+    rm -Rf $NODE_ROOT$KWASM_DIR/active
 fi
 
 if [ ! -f $NODE_ROOT$KWASM_DIR/active ]; then


### PR DESCRIPTION
With the [0.9.0 release](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.0) of `deislabs/containerd-wasm-shims` and the latest updates in `containerd/runwasi`, there is no need to use `crun` for mixed pods with WasmEdge and Linux containers. Therefore, support for crun+wasmedge will be removed for now in favor of the runwasi WasmEdge shim. It is planned to reintroduce support for OCI runtimes in a later version of kwasm-node-installer.

The runwasi WasmEdge shim has the same behavior as the `module.wasm.image/variant: compat-smart` annotation for crun+wasmedge, but no annotation is required. And even better, all other shims can now be used with sidecars as well!

This PR can be tested with the folowing Helm command:
```
helm upgrade --install -n kwasm --create-namespace kwasm-operator kwasm/kwasm-operator \
  --set kwasmOperator.autoProvision="true" \
  --set kwasmOperator.installerImage="ghcr.io/kwasm/kwasm-node-installer:pr-42"
```

Available `RuntimeClasses`:
```yaml
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: slight
handler: slight
---
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: spin
handler: spin
---
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: wws
handler: wws
---
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: lunatic
handler: lunatic
---
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: wasmtime
handler: wasmtime
---
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: wasmedge
handler: wasmedge
---
apiVersion: node.k8s.io/v1
kind: RuntimeClass
metadata:
  name: wasmer
handler: wasmer

```

closes #40 
closes #27 
closes #11