### PR TITLE
chore: bump shim versions to the latest

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -5,8 +5,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN mkdir -p /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.3.0/containerd-shim-wasmedge-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.3.0/containerd-shim-wasmtime-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.3.0/containerd-shim-wasmedge-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.3.0/containerd-shim-wasmtime-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmer%2Fv0.3.0/containerd-shim-wasmer-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/
 
 FROM ${CONTAINERD_RUNWASI} AS containerd_runwasi
 
@@ -26,7 +27,7 @@ FROM busybox
 
 COPY script/installer.sh /script/installer.sh
 COPY --link --from=deislabs_containerd-wasm-shims /assets /assets
-COPY --link --from=containerd_runwasi /containerd-shim-wasmedge-v1 /assets/
-COPY --link --from=containerd_runwasi /containerd-shim-wasmer-v1 /assets/
-COPY --link --from=containerd_runwasi /containerd-shim-wasmtime-v1 /assets/
+COPY --link --from=containerd_runwasi /release/bin/containerd-shim-wasmedge-v1 /assets/
+COPY --link --from=containerd_runwasi /release/bin/containerd-shim-wasmer-v1 /assets/
+COPY --link --from=containerd_runwasi /release/bin/containerd-shim-wasmtime-v1 /assets/
 CMD sh /script/installer.sh wasmedge

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -17,10 +17,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN mkdir /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.3/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.3/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.3/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.3/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
 
 
 FROM busybox

--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -5,8 +5,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN mkdir -p /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.2.0/containerd-shim-wasmedge-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.2.0/containerd-shim-wasmtime-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.3.0/containerd-shim-wasmedge-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.3.0/containerd-shim-wasmtime-linux-$(uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g).tar.gz | tar -xzf - -C /release/bin/
 
 FROM ${CONTAINERD_RUNWASI} AS containerd_runwasi
 
@@ -16,10 +16,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN mkdir /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
-    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.1/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-lunatic-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-slight-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets \
+    && curl -L https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.9.2/containerd-wasm-shims-v1-wws-linux-$(uname -m).tar.gz  | tar -xzf - -C /assets
 
 
 FROM busybox


### PR DESCRIPTION
This PR bumps the containerd-wasm-shims versions to `0.9.2` and runwasi shims versions to `0.3.0` and added the wasmer shim.