### PR TITLE
feat: KWASM_DIR configurable

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -5,9 +5,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN mkdir -p /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.3.0/containerd-shim-wasmedge-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.3.0/containerd-shim-wasmtime-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/ \
-    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmer%2Fv0.3.0/containerd-shim-wasmer-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmedge%2Fv0.4.0/containerd-shim-wasmedge-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmtime%2Fv0.4.0/containerd-shim-wasmtime-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/ \
+    && curl -L https://github.com/containerd/runwasi/releases/download/containerd-shim-wasmer%2Fv0.4.0/containerd-shim-wasmer-$(uname -m | sed s/arm64/aarch64/g | sed s/amd64/x86_64/g).tar.gz | tar -xzf - -C /release/bin/
 
 FROM ${CONTAINERD_RUNWASI} AS containerd_runwasi
 

--- a/script/installer.sh
+++ b/script/installer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -euo pipefail
 
-KWASM_DIR=/opt/kwasm
+KWASM_DIR=${KWASM_DIR:-/opt/kwasm}
 
 CONTAINERD_CONF=/etc/containerd/config.toml
 IS_MICROK8S=false
@@ -60,9 +60,9 @@ if [ ! -f $NODE_ROOT$KWASM_DIR/active ]; then
     elif ls $NODE_ROOT/etc/init.d/k3s > /dev/null 2>&1 ; then
         nsenter --target 1 --mount --uts --ipc --net -- /etc/init.d/k3s restart
     elif $IS_RKE2_AGENT; then
-        nsenter --target 1 --mount --uts --ipc --net -- /bin/systemctl restart rke2-agent
+        nsenter --target 1 --mount --uts --ipc --net -- systemctl restart rke2-agent
     else
-        nsenter -m/$NODE_ROOT/proc/1/ns/mnt -- /bin/systemctl restart containerd
+        nsenter -m/$NODE_ROOT/proc/1/ns/mnt -- systemctl restart containerd
     fi
 else
     echo "No change in containerd/config.toml"


### PR DESCRIPTION
In this PR:

* Make the `KWASM_DIR` value configurable via env vars
* Bump `containerd/runwasi` runtimes to `v0.4.0`
* Rely on `$PATH` to discover the `systemctl` binary location

The motivation of this PR is to make the script also able to provision GKE nodes using the `cos_containerd` image. Such image has many partitions mounted with `ro` or `noexec` or both. For example, the default `/opt/kwasm` dir would land on 

```
/dev/mapper/vroot on / type ext2 (ro,relatime)
```

so the dir could never be created. However there are other partitions where users can read and execute. This PR adds the ability to pass in a custom `KWASM_DIR` value where things will be installed in the hosts.

I'm also bumping some versions to the latest release and also relying on the `$PATH` env var to discover the `systemctl` location rather than passing a full path. Turns out in nodes running `cos_containerd` the binary lives in `/usr/bin/systemctl`. In this decision I'm assuming `$PATH` is always correctly set in RKE and any other K8s distribution. I think it's a pretty safe assumption to make but happy to code a specific GKE case if needed.